### PR TITLE
fix. 'generator' object is not subscriptable

### DIFF
--- a/recommender_datasets/output.py
+++ b/recommender_datasets/output.py
@@ -68,10 +68,10 @@ def write_hdf5_data(filename, data,
                            np.float32,
                            np.int32)):
 
-    if not isinstance(data[0], np.ndarray):
-        arrays = _to_numpy(data, dtype)
-    else:
+    if isinstance(data, tuple) and isinstance(data[0], np.ndarray):
         arrays = data
+    else:
+        arrays = _to_numpy(data, dtype)
 
     output_dir = os.path.join(_common.get_data_home(), 'output')
 


### PR DESCRIPTION
Fixes the issue in;
https://github.com/maciejkula/recommender_datasets/issues/5


For movielens dataset data object is not a tuple and should be converted to numpy array.
For yoochoose, we can use the data object as it is.

